### PR TITLE
Rename temperature metric

### DIFF
--- a/collectors/collector.go
+++ b/collectors/collector.go
@@ -28,7 +28,7 @@ type bsbmpCollector struct {
 func NewBsbmpCollector(c client.Sensor) *bsbmpCollector {
 	sensor = c
 	return &bsbmpCollector{
-		TemperatureC: prometheus.NewDesc("bsbmp_temperature_celcius",
+		TemperatureC: prometheus.NewDesc("bsbmp_temp_celsius",
 			"The temperature in Celsius",
 			nil, nil,
 		),


### PR DESCRIPTION
Fix a typo in temperature metric name and conform to standards set by official Prometheus exporters by shortening temperature to temp.

`bsbmp_temperature_celcius` -> `bsbmp_temp_celsius`

One can't mistake _temp_ (temperature) for temporary as there is _celsius_ in metric name.

Resolves #15 